### PR TITLE
continue to next middleware if no file is served

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,11 @@ function broccoliServer(options) {
 		reload()
 	})
 
-	return function* middleware() {
-		var directory = yield watcher
-
-		yield send(this, this.path, { root: directory })
+	return function* middleware(next) {
+		if (this.method == 'HEAD' || this.method == 'GET') {
+			var directory = yield watcher
+			if (yield send(this, this.path, { root: directory })) return
+		}
+		yield* next
 	}
 }


### PR DESCRIPTION
If the request does not match any static file in ```var directory```, yield next to continue to the next middleware (if there is one). This allows you to request ```/styles.css``` which will be handled by this middleware and also ```/some-route```, which would otherwise be swallowed by this middleware and fail when no matching file is found